### PR TITLE
Add new modules for /build REST API and corresponding Angular directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .classpath
 .project
 .settings
+node
+node_modules
 target

--- a/angularjs-project-support/README.md
+++ b/angularjs-project-support/README.md
@@ -1,0 +1,14 @@
+## AngularJS Project Support
+
+This module contains re-usable AngularJS components. The deliverable for this module is a jar that provides these resources to Servlet 3.0 environments
+(google "Servlet 3.0 static resources" for more).
+
+### Build
+
+The "build" directive is intended for use with the `ProjectController#build` API provided by the spring-project-rest-api module.
+
+Add the build_directive.js script to your page, and render it with:
+
+```
+<build api-url="build"></build>
+```

--- a/angularjs-project-support/karma-maven.conf.js
+++ b/angularjs-project-support/karma-maven.conf.js
@@ -1,0 +1,85 @@
+/*
+ * Board of Regents of the University of Wisconsin System
+ * licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// Karma configuration
+// Generated on Fri Oct 24 2014 10:06:09 GMT-0500 (Central Daylight Time)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'node_modules/angular/angular.js',
+      'node_modules/angular-mocks/angular-mocks.js',
+      'src/main/javascript/**/*.js',
+      'src/test/javascript/test-app.js',
+      'src/test/javascript/**/*.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome', 'Firefox'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true
+  });
+};

--- a/angularjs-project-support/karma.conf.js
+++ b/angularjs-project-support/karma.conf.js
@@ -1,0 +1,85 @@
+/*
+ * Board of Regents of the University of Wisconsin System
+ * licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// Karma configuration
+// Generated on Fri Oct 24 2014 10:06:09 GMT-0500 (Central Daylight Time)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'node_modules/angular/angular.js',
+      'node_modules/angular-mocks/angular-mocks.js',
+      'src/main/javascript/**/*.js',
+      'src/test/javascript/test-app.js',
+      'src/test/javascript/**/*.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  });
+};

--- a/angularjs-project-support/package.json
+++ b/angularjs-project-support/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "angularjs-project-support",
+  "version": "0.0.1-SNAPSHOT",
+  "description": "AngularJS Project Support",
+  "devDependencies": {
+    "angular": "1.3.8",
+    "angular-mocks": "1.3.8",
+    "karma": "^0.12.24",
+    "karma-chrome-launcher": "^0.1.5",
+    "karma-jasmine": "^0.1.5"
+  }
+}

--- a/angularjs-project-support/pom.xml
+++ b/angularjs-project-support/pom.xml
@@ -1,0 +1,100 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.nblair</groupId>
+		<artifactId>developer-tools</artifactId>
+		<version>0.3.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>angularjs-project-support</artifactId>
+	<name>AngularJS Project Support</name>
+	<description>Provides re-usable AngularJS components (directives, controllers, etc) bundled as a Servlet 3.0 "webjar".</description>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.eirslett</groupId>
+				<artifactId>frontend-maven-plugin</artifactId>
+				<version>0.0.23</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+				<executions>
+					<execution>
+						<id>install node and npm</id>
+						<goals>
+							<goal>install-node-and-npm</goal>
+						</goals>
+						<configuration>
+							<nodeVersion>v0.10.30</nodeVersion>
+							<npmVersion>1.4.21</npmVersion>
+						</configuration>
+					</execution>
+					<execution>
+						<id>npm install</id>
+						<goals>
+							<goal>npm</goal>
+						</goals>
+						<!-- Optional configuration which provides for running any npm command -->
+						<configuration>
+							<arguments>install</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<id>javascript tests</id>
+						<goals>
+							<goal>karma</goal>
+						</goals>
+						<configuration>
+							<karmaConfPath>karma-maven.conf.js</karmaConfPath>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.7</version>
+				<executions>
+					<execution>
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/classes/META-INF/com.github.nblair/${project.version}</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/javascript</directory>
+									<filtering>false</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>frontend-tests</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.eirslett</groupId>
+						<artifactId>frontend-maven-plugin</artifactId>
+						<configuration>
+							<skip>false</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/angularjs-project-support/src/main/javascript/build/build_directive.js
+++ b/angularjs-project-support/src/main/javascript/build/build_directive.js
@@ -1,0 +1,40 @@
+/*
+ * Board of Regents of the University of Wisconsin System
+ * licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+'use strict';
+
+(function() {
+	var app = angular.module('angularjs-project-support.build', []);
+
+	app.directive('build', function() {
+		return {
+			restrict: 'E',
+			scope: {
+    			apiUrl: '@apiUrl'
+    		},
+			template: '<p class="text-muted pull-right">Revision {{buildNumber}} (Version {{projectVersion}}<span ng-show="scmBranch"> from {{scmBranch}} branch</span>)</p>',
+			controller: ['$scope', '$http', function($scope, $http) {
+				$http
+					.get($scope.apiUrl)
+					.success(function(data) {
+						$scope.buildNumber = data.buildNumber;
+						$scope.projectVersion= data.projectVersion;
+						$scope.scmBranch = data.scmBranch;
+					});
+			}],
+		}
+	});
+})();

--- a/angularjs-project-support/src/test/javascript/build/build_directive.test.js
+++ b/angularjs-project-support/src/test/javascript/build/build_directive.test.js
@@ -1,0 +1,78 @@
+/*
+ * Board of Regents of the University of Wisconsin System
+ * licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+'use strict';
+
+describe("directive: build", function() {
+
+	var element, scope, $compile_, $httpBackend;
+	
+	beforeEach(module('angularjs-project-support'));
+
+	beforeEach(inject(function($rootScope, $compile,  _$httpBackend_) {
+		scope = $rootScope.$new();
+		
+		$httpBackend = _$httpBackend_;
+		$compile_ = $compile;
+	}));
+		
+	function compileDirective() {
+		element ='<build api-url="build"></build>';
+
+		element = $compile_(element)(scope);
+		$httpBackend.flush();
+		scope.$digest();
+    }
+	
+	it('should show branch when scmBranch available', function(){
+		$httpBackend.when('GET', 'build').respond(
+				{
+					buildNumber: "f0b3539",
+					scmBranch: "scmBranch-on-tag",
+					projectVersion: "1.3.1-SNAPSHOT",
+					timestamp: "22.04.2015 @ 13:46:15 CDT"
+				});
+		compileDirective();
+		
+		expect(element.find('span').text()).toBe(' from scmBranch-on-tag branch');
+		expect(element.find('span').hasClass('ng-hide')).toBe(false);
+	});
+	it('should not show branch when scmBranch is null', function(){
+		$httpBackend.when('GET', 'build').respond(
+				{
+					buildNumber: "f0b3539",
+					scmBranch: null,
+					projectVersion: "1.3.0",
+					timestamp: "22.04.2015 @ 13:46:15 CDT"
+				});
+		compileDirective();
+		
+		expect(element.find('span').text()).toBe(' from  branch');
+		expect(element.find('span').hasClass('ng-hide')).toBe(true);
+	});
+	it('should not show branch when scmBranch is blank', function(){
+		$httpBackend.when('GET', 'build').respond(
+				{
+					buildNumber: "f0b3539",
+					scmBranch: '',
+					projectVersion: "1.3.0",
+					timestamp: "22.04.2015 @ 13:46:15 CDT"
+				});
+		compileDirective();
+		expect(element.find('span').text()).toBe(' from  branch');
+		expect(element.find('span').hasClass('ng-hide')).toBe(true);
+	});
+});

--- a/angularjs-project-support/src/test/javascript/test-app.js
+++ b/angularjs-project-support/src/test/javascript/test-app.js
@@ -1,0 +1,24 @@
+/*
+ * Board of Regents of the University of Wisconsin System
+ * licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+'use strict';
+
+(function() {
+ var app = angular.module('angularjs-project-support', [
+	'angularjs-project-support.build' 
+ ]);
+ 
+})();

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.nblair</groupId>
 	<artifactId>developer-tools</artifactId>
-	<version>0.2.1-SNAPSHOT</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<parent>
 		<groupId>org.sonatype.oss</groupId>
 		<artifactId>oss-parent</artifactId>
@@ -40,6 +40,8 @@
 		<module>preauth-simulation-filter</module>
 		<module>preauth-simulation-filter-servlet_2.5</module>
 		<module>spring-profile-conditional-filter</module>
+		<module>spring-project-rest-api</module>
+		<module>angularjs-project-support</module>
 	</modules>
 
 	<dependencyManagement>
@@ -49,6 +51,16 @@
 				<artifactId>guava</artifactId>
 				<version>18.0</version>
 			</dependency>
+			<dependency>
+				<groupId>com.mangofactory</groupId>
+				<artifactId>swagger-springmvc</artifactId>
+				<version>1.0.2</version>
+			</dependency>
+			<dependency>
+				<groupId>javax.inject</groupId>
+				<artifactId>javax.inject</artifactId>
+				<version>1</version>
+			</dependency>	
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>javax.servlet-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,8 @@
 						<exclude>LICENSE</exclude>
 						<exclude>NOTICE</exclude>
 						<exclude>.gitignore</exclude>
+						<exclude>**/node/</exclude>
+						<exclude>**/node_modules/</exclude>
 					</excludes>
 				</configuration>
 				<executions>

--- a/preauth-simulation-filter-servlet_2.5/pom.xml
+++ b/preauth-simulation-filter-servlet_2.5/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.github.nblair</groupId>
 		<artifactId>developer-tools</artifactId>
-		<version>0.2.1-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>preauth-simulation-filter-servlet_2.5</artifactId>
 	<name>Pre-Authentication Simulation Filter (Servlet 2.5)</name>

--- a/preauth-simulation-filter/pom.xml
+++ b/preauth-simulation-filter/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.github.nblair</groupId>
 		<artifactId>developer-tools</artifactId>
-		<version>0.2.1-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>preauth-simulation-filter</artifactId>
 	<name>Pre-Authentication Simulation Filter</name>

--- a/spring-profile-conditional-filter/pom.xml
+++ b/spring-profile-conditional-filter/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.github.nblair</groupId>
 		<artifactId>developer-tools</artifactId>
-		<version>0.2.1-SNAPSHOT</version>
+		<version>0.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-profile-conditional-filter</artifactId>
 	<name>Spring Profile Conditional Filter</name>

--- a/spring-project-rest-api/README.md
+++ b/spring-project-rest-api/README.md
@@ -1,0 +1,54 @@
+## spring-project-rest-api
+
+This module provides Spring `@Controller`s that expose a REST API for information about your project, like Build information and `Environment.getActiveProfiles()`.
+
+### Adding to your project
+
+Add this dependency to your project:
+
+```
+<dependency>
+  <groupId>com.github.nblair</groupId>
+  <artifactId>spring-project-rest-api</artifactId>
+  <version>0.3.0</version>
+</dependency>
+```
+
+Next, if you want the Build API to return project information, you'll need the help of a few Maven plugins to generate the necessary properties. 
+Create a file named `buildNumber.properties` in src/main/resources of your project, and copy the text from buildNumber-SAMPLE.properties.
+
+Then, Add the following to your build plugins:
+
+```
+     <build>
+     	<resources>
+    		<resource>
+        		<directory>${basedir}/src/main/resources</directory>
+        		<filtering>true</filtering>
+   	 		</resource>
+		</resources>
+        <plugins>
+           ...
+           <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                         </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                	<dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
+               		<generateGitPropertiesFile>false</generateGitPropertiesFile>
+    				<skip>false</skip>
+                </configuration>
+            </plugin>
+            ...
+         </plugins>
+     </build>
+```
+
+Now that the dependency is installed, simply `@ComponentScan` the `com.github.nblair.project.rest` package in your web configuration.
+You'll find a new API - /build - under your application's context.  

--- a/spring-project-rest-api/buildNumber-SAMPLE.properties
+++ b/spring-project-rest-api/buildNumber-SAMPLE.properties
@@ -1,0 +1,25 @@
+#
+# Board of Regents of the University of Wisconsin System
+# licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a
+# copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# provided via Maven resource filtering
+projectVersion=${project.version}
+# provided by the maven-git-commit-id-plugin: https://github.com/ktoso/maven-git-commit-id-plugin
+git.tags=${git.tags}
+git.branch=${git.branch}
+git.commit.id.abbrev=${git.commit.id.abbrev}
+git.dirty=${git.dirty}
+git.build.time=${git.build.time}

--- a/spring-project-rest-api/pom.xml
+++ b/spring-project-rest-api/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.nblair</groupId>
+		<artifactId>developer-tools</artifactId>
+		<version>0.3.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-project-rest-api</artifactId>
+	<name>Spring Project REST API</name>
+	<description>This module provides Spring @Controllers that expose a REST API for information about your project, like build information and active profiles.</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.mangofactory</groupId>
+			<artifactId>swagger-springmvc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.inject</groupId>
+			<artifactId>javax.inject</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-project-rest-api/src/main/java/com/github/nblair/project/rest/Build.java
+++ b/spring-project-rest-api/src/main/java/com/github/nblair/project/rest/Build.java
@@ -1,0 +1,131 @@
+/**
+ * Board of Regents of the University of Wisconsin System
+ * licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.github.nblair.project.rest;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean representing project build information.
+ * 
+ * @author Nicholas Blair
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Build {
+  
+  @XmlElement
+  protected String buildNumber;
+  @XmlElement
+  protected String scmBranch;
+  @XmlElement
+  protected String projectVersion;
+  @XmlElement
+  protected String timestamp;
+  protected boolean dirty;
+  /**
+   * 
+   */
+  public Build() {
+  }
+  /**
+   * 
+   * @param buildNumber the value to set for {@link #getBuildNumber()}.
+   */
+  public Build(String buildNumber) {
+    this.buildNumber = buildNumber;
+  }
+  /**
+   * @return the buildNumber
+   */
+  public String getBuildNumber() {
+    return buildNumber;
+  }
+  /**
+   * @param buildNumber the buildNumber to set
+   */
+  public void setBuildNumber(String buildNumber) {
+    this.buildNumber = buildNumber;
+  }
+  /**
+   * @return the scmBranch
+   */
+  public String getScmBranch() {
+    return scmBranch;
+  }
+  /**
+   * @param scmBranch the scmBranch to set
+   */
+  public void setScmBranch(String scmBranch) {
+    this.scmBranch = scmBranch;
+  }
+  /**
+   * @return the projectVersion
+   */
+  public String getProjectVersion() {
+    return projectVersion;
+  }
+  /**
+   * @param projectVersion the projectVersion to set
+   */
+  public void setProjectVersion(String projectVersion) {
+    this.projectVersion = projectVersion;
+  }
+  /**
+   * @return the timestamp
+   */
+  public String getTimestamp() {
+    return timestamp;
+  }
+  /**
+   * @param timestamp the timestamp to set
+   */
+  public void setTimestamp(String timestamp) {
+    this.timestamp = timestamp;
+  }
+  /**
+   * @return true if the build was produced from a locally modified working copy
+   */
+  public boolean isDirty() {
+    return dirty;
+  }
+  /**
+   * @param dirty the dirty to set
+   */
+  public void setDirty(boolean dirty) {
+    this.dirty = dirty;
+  }
+  /* (non-Javadoc)
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("Build [buildNumber=");
+    builder.append(buildNumber);
+    builder.append(", scmBranch=");
+    builder.append(scmBranch);
+    builder.append(", projectVersion=");
+    builder.append(projectVersion);
+    builder.append(", timestamp=");
+    builder.append(timestamp);
+    builder.append("]");
+    return builder.toString();
+  }
+}

--- a/spring-project-rest-api/src/main/java/com/github/nblair/project/rest/ProjectController.java
+++ b/spring-project-rest-api/src/main/java/com/github/nblair/project/rest/ProjectController.java
@@ -1,0 +1,99 @@
+/**
+ * Board of Regents of the University of Wisconsin System
+ * licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * 
+ */
+package com.github.nblair.project.rest;
+
+
+import javax.inject.Inject;
+
+import org.springframework.core.env.Environment;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.wordnik.swagger.annotations.ApiOperation;
+
+/**
+ * {@link Controller} providing a REST API for project information.
+ * 
+ * Expects the {@link Environment} to be injected and provide a number of properties.
+ * Here is an example of the properties you'll need:
+ * <pre>
+# provided via Maven resource filtering
+projectVersion=${project.version}
+# provided by the maven-git-commit-id-plugin: https://github.com/ktoso/maven-git-commit-id-plugin
+git.tags=${git.tags}
+git.branch=${git.branch}
+git.commit.id.abbrev=${git.commit.id.abbrev}
+git.dirty=${git.dirty}
+git.build.time=${git.build.time}
+ </pre>
+ * 
+ * @author Nicholas Blair
+ */
+@Controller
+public class ProjectController {
+
+  public static final String GIT_BUILD_TIME = "git.build.time";
+  public static final String GIT_BRANCH = "git.branch";
+  public static final String GIT_COMMIT_ID_ABBREV = "git.commit.id.abbrev";
+  public static final String GIT_DIRTY = "git.dirty";
+  public static final String GIT_TAGS = "git.tags";
+  public static final String PROJECT_VERSION = "projectVersion";
+  
+  @Inject
+  private Environment environment;
+  /**
+   * Visible for testing.
+   * 
+   * @param environment the environment to set
+   */
+  void setEnvironment(Environment environment) {
+    this.environment = environment;
+  }
+  /**
+   * 
+   * @return the current {@link Build} information
+   */
+  @ApiOperation(value="Build information", notes="Retrieve project build information.")
+  @RequestMapping(value="/build", method=RequestMethod.GET, produces={ MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE })
+  public @ResponseBody Build build() {
+    Build build = new Build(environment.getProperty(GIT_COMMIT_ID_ABBREV));
+    if(StringUtils.isEmpty(environment.getProperty(GIT_TAGS))) {
+      build.setScmBranch(environment.getProperty(GIT_BRANCH));
+    }
+    build.setProjectVersion(environment.getProperty(PROJECT_VERSION));
+    build.setTimestamp(environment.getProperty(GIT_BUILD_TIME));
+    // default dirty field to 'true' if property isn't available
+    build.setDirty(Boolean.parseBoolean(environment.getProperty(GIT_DIRTY, "true")));
+    return build;
+  }
+  /**
+   * 
+   * @return the current {@link Environment#getActiveProfiles()}
+   */
+  @ApiOperation(value="Active Profiles", notes="Retrieve active profiles for the environment.")
+  @RequestMapping(value="/activeProfiles", method=RequestMethod.GET, produces={ MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE })
+  public @ResponseBody String[] activeProfiles() {
+   return environment.getActiveProfiles();
+  }
+}

--- a/spring-project-rest-api/src/test/java/com/github/nblair/project/rest/ProjectControllerTest.java
+++ b/spring-project-rest-api/src/test/java/com/github/nblair/project/rest/ProjectControllerTest.java
@@ -1,0 +1,94 @@
+/**
+ * Board of Regents of the University of Wisconsin System
+ * licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * 
+ */
+package com.github.nblair.project.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Tests for {@link ProjectController}.
+ * 
+ * @author Nicholas Blair
+ */
+public class ProjectControllerTest {
+
+  /**
+   * Verify stable behavior when all known build properties are missing.
+   */
+  @Test
+  public void build_noPropertiesSet() {
+    ProjectController controller = new ProjectController();
+    Environment environment = new MockEnvironment();
+    controller.setEnvironment(environment);
+    
+    Build build = controller.build();
+    assertNull(build.getBuildNumber());
+    assertNull(build.getProjectVersion());
+    assertNull(build.getScmBranch());
+    assertNull(build.getTimestamp());
+    assertTrue(build.isDirty()); 
+  }
+  /**
+   * Experiment for successful scenario representing a release.
+   */
+  @Test
+  public void build_successful_release() {
+    ProjectController controller = new ProjectController();
+    Environment env = new MockEnvironment()
+      .withProperty(ProjectController.PROJECT_VERSION, "1.2.3")
+      .withProperty(ProjectController.GIT_TAGS, "foo-1.2.3")
+      .withProperty(ProjectController.GIT_COMMIT_ID_ABBREV, "abcd123")
+      .withProperty(ProjectController.GIT_DIRTY, "false");
+    controller.setEnvironment(env);
+    
+    Build build = controller.build();
+    assertEquals("abcd123", build.getBuildNumber());
+    assertEquals("1.2.3", build.getProjectVersion());
+    assertNull(build.getScmBranch());
+    assertFalse(build.isDirty()); 
+  }
+  /**
+   * Experiment for successful scenario representing a transient build.
+   */
+  @Test
+  public void build_successful_snapshot() {
+    ProjectController controller = new ProjectController();
+    Environment env = new MockEnvironment()
+      .withProperty(ProjectController.PROJECT_VERSION, "1.2.4-SNAPSHOT")
+      .withProperty(ProjectController.GIT_BRANCH, "something/branchname")
+      .withProperty(ProjectController.GIT_COMMIT_ID_ABBREV, "abcd123")
+      .withProperty(ProjectController.GIT_DIRTY, "false");
+    controller.setEnvironment(env);
+    
+    Build build = controller.build();
+    assertEquals("abcd123", build.getBuildNumber());
+    assertEquals("1.2.4-SNAPSHOT", build.getProjectVersion());
+    assertEquals("something/branchname", build.getScmBranch());
+    assertFalse(build.isDirty()); 
+  }
+  
+ 
+}


### PR DESCRIPTION
This pull request adds 2 new modules that will allow us to add the "/build" REST API and the corresponding AngularJS directive to any of the projects in our portfolio.
